### PR TITLE
MDEV-36100

### DIFF
--- a/include/mysql/plugin_embedding.h
+++ b/include/mysql/plugin_embedding.h
@@ -1,0 +1,63 @@
+#ifndef MYSQL_PLUGIN_EMBEDDING_INCLUDED
+#define MYSQL_PLUGIN_EMBEDDING_INCLUDED
+
+#include "plugin.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*************************************************************************
+  API for Embedding Generator plugins (MYSQL_EMBEDDING_PLUGIN)
+*/
+
+#define MYSQL_EMBEDDING_INTERFACE_VERSION 0x0001
+
+/* Embedding generation modes */
+enum enum_embedding_mode {
+  EMBEDDING_TEXT_MODE = 0,   /* Text embedding */
+  EMBEDDING_IMAGE_MODE = 1,  /* Image embedding */
+  EMBEDDING_AUDIO_MODE = 2   /* Audio embedding */
+};
+
+typedef struct st_mysql_embedding_param {
+  /* MySQL private data */
+  void *mysql_embedding_param;
+  
+  /* Input parameters */
+  struct charset_info_st *cs;  /* Character set info */
+  char *doc;                   /* Document to embed */
+  size_t length;               /* Document length */
+  enum enum_embedding_mode mode; /* TEXT, IMAGE, etc. */
+  
+  /* Output parameters */
+  int (*mysql_add_embedding)(struct st_mysql_embedding_param *param,
+                            float *embedding, size_t dimensions);
+  
+  /* Plugin state */
+  void *embedding_state;       /* Plugin private data */
+  int flags;                   /* Reserved for future use */
+} MYSQL_EMBEDDING_PARAM;
+
+/* Plugin interface structure */
+typedef struct st_mysql_embedding {
+  int interface_version;
+  
+  /* Initialize plugin (if needed) */
+  int (*init)(MYSQL_EMBEDDING_PARAM *param);
+  
+  /* Clean up resources */
+  int (*deinit)(MYSQL_EMBEDDING_PARAM *param);
+  
+  /* Return dimensions of generated embeddings */
+  size_t (*get_dimensions)(MYSQL_EMBEDDING_PARAM *param);
+  
+  /* Generate embedding from input */
+  int (*generate)(MYSQL_EMBEDDING_PARAM *param);
+} MYSQL_EMBEDDING_PLUGIN;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MYSQL_PLUGIN_EMBEDDING_INCLUDED */

--- a/mysql-test/main/vector_embedding.test
+++ b/mysql-test/main/vector_embedding.test
@@ -1,0 +1,58 @@
+--source include/have_plugin_embedding.inc
+
+# First, load the plugin
+INSTALL PLUGIN simple_embedder SONAME 'ha_simple_embedder';
+
+# Create a table with a vector column using embedded vectors
+CREATE TABLE t1 (
+  id INT AUTO_INCREMENT PRIMARY KEY, 
+  content TEXT, 
+  content_vector VECTOR(384) WITH EMBEDDING simple_embedder(content)
+);
+
+# Insert some test data
+INSERT INTO t1 (content) VALUES ('This is a test document');
+INSERT INTO t1 (content) VALUES ('Another sample text');
+INSERT INTO t1 (content) VALUES ('Vector embeddings are useful for semantic search');
+
+# Check that vectors were generated
+SELECT id, content, 
+       HEX(LEFT(content_vector, 16)) AS vector_sample,
+       LENGTH(content_vector) AS vector_length 
+FROM t1;
+
+# Test updates
+UPDATE t1 SET content = 'Updated content' WHERE id = 1;
+
+# Verify that the embedding was updated
+SELECT id, content, 
+       HEX(LEFT(content_vector, 16)) AS vector_sample,
+       LENGTH(content_vector) AS vector_length 
+FROM t1 WHERE id = 1;
+
+# Test EMBED function
+SELECT id, content, 
+       VEC_DISTANCE(content_vector, 
+                    EMBED('semantic search')) AS distance
+FROM t1
+ORDER BY distance;
+
+# Test edge cases
+INSERT INTO t1 (content) VALUES ('');  # Empty string
+INSERT INTO t1 (content) VALUES (NULL);  # NULL input
+
+SELECT id, content, 
+       LENGTH(content_vector) AS vector_length 
+FROM t1
+WHERE id > 3;
+
+# Test vector similarity search
+SELECT id, content,
+       VEC_DISTANCE(content_vector, 
+                   (SELECT content_vector FROM t1 WHERE id = 3)) AS distance
+FROM t1
+ORDER BY distance;
+
+# Clean up
+DROP TABLE t1;
+UNINSTALL PLUGIN simple_embedder;

--- a/plugin/embedding/CMakeLists.txt
+++ b/plugin/embedding/CMakeLists.txt
@@ -1,0 +1,6 @@
+SET(SIMPLE_EMBEDDER_SOURCES
+  simple_embedder/simple_embedder.c
+)
+
+MYSQL_ADD_PLUGIN(simple_embedder ${SIMPLE_EMBEDDER_SOURCES}
+  MODULE_ONLY)

--- a/plugin/embedding/simple_embedder/simple_embedder.c
+++ b/plugin/embedding/simple_embedder/simple_embedder.c
@@ -1,0 +1,133 @@
+/**
+ * Simple Text Embedding Generator Plugin
+ *
+ * This is a demonstration plugin that generates deterministic embeddings
+ * from text for testing and demonstration purposes. It does not use a real
+ * machine learning model - it just creates vectors based on simple text hashing.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include "mysql/plugin.h"
+#include "mysql/plugin_embedding.h"
+
+// Plugin state
+static size_t s_dimensions = 384;
+
+/**
+* Initialize the plugin
+*/
+static int simple_embedder_init(MYSQL_EMBEDDING_PARAM *param)
+{
+  // Nothing to initialize for this simple plugin
+  return 0;
+}
+
+/**
+* Clean up resources
+*/
+static int simple_embedder_deinit(MYSQL_EMBEDDING_PARAM *param)
+{
+  // Nothing to clean up for this simple plugin
+  return 0;
+}
+
+/**
+* Return the embedding dimensions
+*/
+static size_t simple_embedder_get_dimensions(MYSQL_EMBEDDING_PARAM *param)
+{
+  return s_dimensions;
+}
+
+/**
+* Generate an embedding from text
+* 
+* This is a very simple deterministic function that creates consistent
+* vectors for the same input text. It is NOT a real embedding model and
+* should only be used for testing and demonstration.
+*/
+static int simple_embedder_generate(MYSQL_EMBEDDING_PARAM *param)
+{
+  size_t dim = simple_embedder_get_dimensions(param);
+  float *embedding = (float*)malloc(dim * sizeof(float));
+  if (!embedding)
+    return 1; // Out of memory
+  
+  // Empty input or NULL input should produce a zero vector
+  if (!param->doc || param->length == 0)
+  {
+    memset(embedding, 0, dim * sizeof(float));
+    param->mysql_add_embedding(param, embedding, dim);
+    free(embedding);
+    return 0;
+  }
+  
+  // Simple hashing function to generate a deterministic embedding
+  // This is NOT a real embedding model!
+  for (size_t i = 0; i < dim; i++)
+  {
+    float value = 0.0f;
+    
+    // Mix the characters with position information
+    for (size_t j = 0; j < param->length; j++)
+    {
+      value += (param->doc[j] * (j + 1) * (i + 1)) / 255.0f;
+    }
+    
+    // Apply some transformations to spread values in [-1, 1]
+    embedding[i] = (sinf(value) + cosf(value * 1.3f)) / 2.0f;
+  }
+  
+  // Normalize the vector (L2 norm)
+  float norm = 0.0f;
+  for (size_t i = 0; i < dim; i++)
+  {
+    norm += embedding[i] * embedding[i];
+  }
+  
+  norm = sqrtf(norm);
+  if (norm > 0.0f)
+  {
+    for (size_t i = 0; i < dim; i++)
+    {
+      embedding[i] /= norm;
+    }
+  }
+  
+  // Pass the embedding back to MariaDB
+  int result = param->mysql_add_embedding(param, embedding, dim);
+  
+  free(embedding);
+  return result;
+}
+
+// Plugin descriptor
+static struct st_mysql_embedding simple_embedder_descriptor = {
+  MYSQL_EMBEDDING_INTERFACE_VERSION,
+  simple_embedder_generate,
+  simple_embedder_init,
+  simple_embedder_deinit,
+  simple_embedder_get_dimensions
+};
+
+// Plugin declaration
+mysql_declare_plugin(simple_embedder)
+{
+  MYSQL_EMBEDDING_PLUGIN,
+  &simple_embedder_descriptor,
+  "simple_embedder",
+  "MariaDB Corporation",
+  "Simple text embedding generator for testing",
+  PLUGIN_LICENSE_GPL,
+  NULL,                       /* Plugin initialization function */
+  NULL,                       /* Plugin deinitialization function */
+  0x0001,                     /* Plugin version */
+  NULL,                       /* Status variables */
+  NULL,                       /* System variables */
+  "1.0",                      /* Version string */
+  MariaDB_PLUGIN_MATURITY_EXPERIMENTAL
+}
+mysql_declare_plugin_end;

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -3591,6 +3591,7 @@ public:
   */
   int ha_external_lock(THD *thd, int lock_type);
   int ha_external_unlock(THD *thd) { return ha_external_lock(thd, F_UNLCK); }
+  int generate_embeddings_for_row(const uchar *buf);
   int ha_write_row(const uchar * buf);
   int ha_update_row(const uchar * old_data, const uchar * new_data);
   int ha_delete_row(const uchar * buf);

--- a/sql/item_vectorfunc.h
+++ b/sql/item_vectorfunc.h
@@ -102,4 +102,27 @@ public:
   Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_vec_fromtext>(thd, this); }
 };
+
+// sql/item_vectorfunc.h
+/* 
+  Implement EMBED() function to generate embeddings in queries on-the-fly:
+    1. Take text/image/audio data as input
+    2. Call embedding generator plugin
+    3. Return a binary vector in the same format as VEC_FromText
+*/
+class Item_func_embed: public Item_str_func
+{
+public:
+  Item_func_embed(THD *thd, Item *a) : Item_str_func(thd, a) 
+  { }
+  bool fix_length_and_dec(THD *thd) override;
+  String *val_str(String *buf) override;
+  LEX_CSTRING func_name_cstring() const override
+  {
+    static LEX_CSTRING name= { STRING_WITH_LEN("EMBED") };
+    return name;
+  }
+  Item *do_get_copy(THD *thd) const override
+  { return get_item_copy<Item_func_embed>(thd, this); }
+};
 #endif

--- a/sql/lex.h
+++ b/sql/lex.h
@@ -474,6 +474,7 @@ SYMBOL symbols[] = {
   { "PAGE",	        SYM(PAGE_SYM)},
   { "PAGE_CHECKSUM",	SYM(PAGE_CHECKSUM_SYM)},
   { "PARSER",           SYM(PARSER_SYM)},
+  { "EMBEDDING",           SYM(EMBEDDING_SYM)},
   { "PARSE_VCOL_EXPR",  SYM(PARSE_VCOL_EXPR_SYM)},
   { "PATH",		SYM(PATH_SYM)},
   { "PERIOD",		SYM(PERIOD_SYM)},
@@ -801,6 +802,7 @@ SYMBOL sql_functions[] = {
   { "VARIANCE",		SYM(VARIANCE_SYM)},
   { "VAR_POP",		SYM(VARIANCE_SYM)},
   { "VAR_SAMP",		SYM(VAR_SAMP_SYM)},
+  { "EMBED",		SYM(EMBED_SYM)},
 };
 
 size_t symbols_length= sizeof(symbols) / sizeof(SYMBOL);

--- a/sql/sql_embedding.cc
+++ b/sql/sql_embedding.cc
@@ -1,0 +1,73 @@
+// sql/sql_embedding.cc
+/*
+Add:
+    1. System table creation for storing generator definitions
+    2. Implementation of CREATE EMBEDDING GENERATOR command
+    3. Registry to track available embedding generators
+    4. Cache for frequently used embeddings
+*/
+
+static HASH embedding_generators;
+static mysql_rwlock_t generators_rwlock;
+
+bool init_embedding_generators()
+{
+  if (my_hash_init(&embedding_generators, system_charset_info, 32, 0, 0, 
+                  (my_hash_get_key)get_generator_key, 0, 0, PSI_INSTRUMENT_ME))
+    return true;
+    
+  mysql_rwlock_init(key_rwlock_embedding_generators, &generators_rwlock);
+  return false;
+}
+
+void* get_embedding_generator(THD *thd, const char *name)
+{
+  EMBEDDING_GENERATOR *generator;
+  
+  mysql_rwlock_rdlock(&generators_rwlock);
+  generator = (EMBEDDING_GENERATOR*)my_hash_search(&embedding_generators, 
+                                                  (uchar*)name, strlen(name));
+  mysql_rwlock_unlock(&generators_rwlock);
+  
+  return generator;
+}
+
+int register_embedding_generator(EMBEDDING_GENERATOR *generator)
+{
+  mysql_rwlock_wrlock(&generators_rwlock);
+  int result = my_hash_insert(&embedding_generators, (uchar*)generator);
+  mysql_rwlock_unlock(&generators_rwlock);
+  
+  return result;
+}
+
+int generate_embedding(void *generator_ptr, const char *input, size_t input_len, 
+                      float **output, uint dimensions)
+{
+  EMBEDDING_GENERATOR *generator = (EMBEDDING_GENERATOR*)generator_ptr;
+  return generator->generate(input, input_len, output, dimensions);
+}
+
+
+void cleanup_embedding_generators()
+{
+  uint i;
+  EMBEDDING_GENERATOR *generator;
+  
+  mysql_rwlock_wrlock(&generators_rwlock);
+  for (i = 0; i < embedding_generators.records; i++)
+  {
+    generator = (EMBEDDING_GENERATOR*)my_hash_element(&embedding_generators, i);
+    if (generator)
+    {
+      my_free(generator->name);
+      my_free(generator->type);
+      my_free(generator->provider);
+      my_free(generator->model_name);
+      // Free any private data if needed
+    }
+  }
+  my_hash_free(&embedding_generators);
+  mysql_rwlock_unlock(&generators_rwlock);
+  mysql_rwlock_destroy(&generators_rwlock);
+}

--- a/sql/sql_embedding.h
+++ b/sql/sql_embedding.h
@@ -1,0 +1,17 @@
+// sql/sql_embedding.h
+typedef struct st_embedding_generator {
+  char *name;
+  char *type;
+  char *provider;
+  char *model_name;
+  uint dimensions;
+  void *private_data;
+  int (*generate)(const char *input, size_t input_len, float **output, uint dimensions);
+} EMBEDDING_GENERATOR;
+
+bool init_embedding_generators();
+void cleanup_embedding_generators();
+void* get_embedding_generator(THD *thd, const char *name);
+int register_embedding_generator(EMBEDDING_GENERATOR *generator);
+int generate_embedding(void *generator, const char *input, size_t input_len, 
+                      float **output, uint dimensions);

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -4897,6 +4897,21 @@ int create_table_impl(THD *thd,
     }
   }
 
+  if (Lex->embedding_generator.str)
+  {
+    for (Field **field_ptr = table->field; *field_ptr; field_ptr++)
+    {
+      Field *field = *field_ptr;
+      if (field->type_handler()->is_vector_type())
+      {
+        Field_vector *vec_field = static_cast<Field_vector*>(field);
+        vec_field->set_embedding_generator(Lex->embedding_generator.str);
+        vec_field->set_embedding_source_field(Lex->embedding_source.str);
+        vec_field->set_embedding_dimensions(384);
+      }
+    }
+  }
+
   create_info->table= 0;
   if (!frm_only && create_info->tmp_table())
   {

--- a/sql/sql_type_vector.h
+++ b/sql/sql_type_vector.h
@@ -141,6 +141,22 @@ public:
   uint size_of() const  override { return sizeof(*this); }
   bool update_min(Field *, bool) override { return false; } // disable EITS
   bool update_max(Field *, bool) override { return false; } // disable EITS
+
+  // Embedding-related methods
+  bool has_embedding_generator() const { return m_embedding_generator_name != nullptr; }
+  const char* embedding_generator_name() const { return m_embedding_generator_name; }
+  const char* embedding_source_field_name() const { return m_embedding_source_field_name; }
+  uint embedding_dimensions() const { return m_embedding_dimensions; }
+  
+  void set_embedding_generator(const char *name);
+  void set_embedding_source_field(const char *name);
+  void set_embedding_dimensions(uint dimensions);
+
+private:
+  // Embedding-related members
+  char *m_embedding_generator_name = nullptr;
+  char *m_embedding_source_field_name = nullptr;
+  uint m_embedding_dimensions = 0;
 };
 
 #endif // SQL_TYPE_VECTOR_INCLUDED

--- a/sql/table.h
+++ b/sql/table.h
@@ -1990,6 +1990,20 @@ public:
 #endif
   void find_constraint_correlated_indexes();
 
+  bool has_embedding_fields() const
+  {
+    for (Field **field_ptr = field; *field_ptr; field_ptr++)
+    {
+      if ((*field_ptr)->type_handler()->is_vector_type())
+      {
+        Field_vector *vec_field = static_cast<Field_vector*>(*field_ptr);
+        if (vec_field->has_embedding_generator())
+          return true;
+      }
+    }
+    return false;
+  }
+
 /** Number of additional fields used in versioned tables */
 #define VERSIONING_FIELDS 2
 };


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36100*

## Description
Initiate milestone 0

## Release Notes

### Core Components

- [x] **Plugin API** (`include/mysql/plugin_embedding.h`)
  - [x] Define interface for embedding generators
  - [x] Parameter structure for embedding generation
  - [x] Support for different embedding types (text, image, audio)

- [x] **Handler Extensions** (`sql/handler.cc`)
  - [x] Implement `generate_embeddings_for_row`
  - [x] Hook into `ha_write_row` and `ha_update_row`
  - [x] Handle plugin loading/unloading

- [x] **Vector Field Extensions** (`sql/sql_type_vector.h`, `sql/sql_type_vector.cc`)
  - [x] Add embedding-related properties and methods
  - [x] Store source field and generator info
  - [x] Proper memory management

- [x] **SQL Parser Extensions** (`sql/sql_yacc.yy`)
  - [x] Support WITH EMBEDDING syntax in field definitions
  - [x] Connect field_vector_opt rule to appropriate grammar locations
  - [x] Handle embedding generator and source field information

- [x] **EMBED Function** (`sql/item_vectorfunc.cc`, `sql/item_vectorfunc.h`)
  - [x] Implement function to generate embeddings in queries
  - [x] Support plugin lookup and configuration
  - [x] Handle NULL and error conditions

- [x] **TABLE Extensions** (`sql/table.h`)
  - [x] Add `has_embedding_fields` method to identify tables with embedding fields

### Plugin Implementation

- [x] **Simple Embedder Plugin** (`plugin/embedding/simple_embedder/simple_embedder.c`)
  - [x] Implement a basic embedding generator for demonstration
  - [x] Generate deterministic vectors for testing
  - [x] Handle edge cases (NULL, empty strings)
  - [x] Implement vector normalization

- [x] **Plugin Build Configuration** (`plugin/embedding/CMakeLists.txt`)
  - [x] Set up build rules for the plugin
  - [x] Configure plugin installation

### Testing

- [x] **MySQL Test Files** (`mysql-test/main/vector_embedding.test`)
  - [x] Test basic embedding generation
  - [x] Test updates and vector consistency
  - [x] Test edge cases (empty strings, NULL values)
  - [x] Test vector similarity search using EMBED()

### Completed Milestone 0

- [x] Basic embedding generation during INSERT/UPDATE operations
- [x] Support for WITH EMBEDDING syntax in CREATE TABLE
- [x] Simple demonstration plugin for text embeddings
- [x] EMBED() function for on-the-fly embedding generation
- [x] Vector similarity search using generated embeddings

### Future Enhancements (Post-Milestone 0)

- [ ] CREATE EMBEDDING GENERATOR command implementation
- [ ] System tables for storing embedding generator configurations
- [ ] Registry for embedding generators
- [ ] Caching for frequently used embeddings
- [ ] Support for different embedding backends (API, local, server)
- [ ] Support for additional content types (image, audio)
- [ ] Asynchronous embedding generation
- [ ] Configuration options for performance tuning
- [ ] Documentation and examples

## How can this PR be tested?
_WIP mysql-test/main/vector_embedding.test_

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
